### PR TITLE
fix SnotifyToastConfig.interface.ts

### DIFF
--- a/src/interfaces/SnotifyToastConfig.interface.ts
+++ b/src/interfaces/SnotifyToastConfig.interface.ts
@@ -82,7 +82,7 @@ export interface SnotifyToastConfig {
    * @type {string}
    * @default undefined
    */
-  icon?: string;
+  icon?: string | boolean;
   /**
    * Backdrop opacity.
    * * **Range:** `0.0 - 1.0`.


### PR DESCRIPTION
Update icon type to be `string | boolean` which more accurately reflects the code.